### PR TITLE
Corrected misalignment between __init__.py and Abuse IP DB blocklist …

### DIFF
--- a/abuseipdb/__init__.py
+++ b/abuseipdb/__init__.py
@@ -102,10 +102,11 @@ class NewReport:
 
 class BlacklistedIP:
 
-    def __init__(self, ipAddress, totalReports, abuseConfidenceScore):
+    def __init__(self, ipAddress, countryCode, abuseConfidenceScore, lastReportedAt):
         self.ipAddress = ipAddress
-        self.totalReports = totalReports
+        self.countryCode = countryCode
         self.abuseConfidenceScore = abuseConfidenceScore
+        self.lastReportedAt = lastReportedAt
 
 
 class AbuseIPDB:
@@ -208,8 +209,9 @@ class AbuseIPDB:
                 blacklisted_ips.append(
                     BlacklistedIP(
                         ipAddress=d['ipAddress'],
-                        totalReports=d['totalReports'],
-                        abuseConfidenceScore=d['abuseConfidenceScore']
+                        countryCode=d['countryCode'],
+                        abuseConfidenceScore=d['abuseConfidenceScore'],
+                        lastReportedAt=d['lastReportedAt']
                     )
                 )
             return blacklisted_ips


### PR DESCRIPTION
…API json response.

I was getting a Python dictionary KeyError when using the get_blacklisted_ips() function. The totalReports key was missing from the response dictionary.

See https://docs.abuseipdb.com/#blacklist-endpoint for returned properties. The totalReports property is not returned in queries to the blocklist API endpoint. So, I removed that property from the relevant class, and updated the get_blacklisted_ips() function to remove totalReports and add the properties that are returned (countryCode and lastReportedat).