### PR TITLE
FIX: check() function ignores the maxAgeInDays parameter

### DIFF
--- a/abuseipdb/__init__.py
+++ b/abuseipdb/__init__.py
@@ -146,7 +146,7 @@ class AbuseIPDB:
             params={
                 'ipAddress': ipAddress,
                 'verbose': '',
-                'maxAgeInDays': 90
+                'maxAgeInDays': maxAgeInDays
             }
         ).content.decode()
         check_json = json.loads(check_json)


### PR DESCRIPTION
A small fix in the code to make sure that the `maxAgeInDays` parameter in the `check()` function is used in the function code during the request, instead of being hardcoded at `90` days.